### PR TITLE
avoid using java.File.renameTo as it is unreliable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <version>3.0.0</version>
       <optional>true</optional><!-- needed only for annotations -->
     </dependency>
+    <dependency>
+    	<groupId>com.google.guava</groupId>
+    	<artifactId>guava</artifactId>
+    	<version>16.0.1</version>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.testng</groupId>

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -17,6 +17,7 @@ import com.github.jmchilton.blend4j.galaxy.beans.HistoryDataset;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryExport;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.request.CollectionDescription;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.CollectionResponse;
+import com.google.common.io.Files;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
@@ -117,7 +118,7 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
     File downloadedFile = super.getWebResourceContents(historyId)
         .path(datasetId).path("display").queryParam("to_ext", fileExt)
         .get(File.class);
-    downloadedFile.renameTo(destinationFile);
+    Files.move(downloadedFile, destinationFile);
     FileWriter fr = new FileWriter(downloadedFile);
     fr.close();
   }


### PR DESCRIPTION
In testing on Ubuntu this method always fails (for me at least) to download the file; there are no exceptions but the specified destinationFile is never created. Debugging the issue showed that the call to renameTo always returned false. I can't see any good reason why the rename should be failing in my setup but given that the method is notoriously unreliable I've switched to using Files.move(src,dest) from the Google Common IO library. This appears to work 100% of the time in the testing I've done so far.

I could have used the NIO version of move, but that was introduced in Java 7 and the pom.xml for the project only requires Java 6, so using the Google version seemed to make the most sense.